### PR TITLE
DoS: run handleConn as goroutine

### DIFF
--- a/proxy/server.go
+++ b/proxy/server.go
@@ -3,12 +3,13 @@ package proxy
 import (
 	"context"
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"net"
 	"sync"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
 )
 
 type ServerConfig struct {
@@ -91,10 +92,12 @@ func (rs *server) listen(ctx context.Context, sshServer *ssh.ServerConfig) error
 			log.Error("accept: ", err)
 			continue
 		}
-		err = rs.handleConn(conn, sshServer)
-		if err != nil {
-			log.Error("handleConn: %s", err)
-		}
+		go func() {
+			err = rs.handleConn(conn, sshServer)
+			if err != nil {
+				log.Error("handleConn: %s", err)
+			}
+		}()
 	}
 	return nil
 }


### PR DESCRIPTION
handleConn needs to be executed within a goroutine otherwise a simple "netcat localhost 4222" will block any further incoming connection (connection handling blocks in pre-auth state: https://github.com/golang/go/issues/43521)